### PR TITLE
Fix Prefixer Type in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import * as Prefixer from 'inline-style-prefixer';
+import { Prefix } from "inline-style-prefixer"
 import * as React from 'react';
 
 export type Size = string | number;
@@ -19,7 +19,7 @@ export interface Props {
   onChange?: (newSize: number) => void;
   onResizerClick?: (event: MouseEvent) => void;
   onResizerDoubleClick?: (event: MouseEvent) => void;
-  prefixer?: Prefixer;
+  prefixer?: Prefix;
   style?: React.CSSProperties;
   resizerStyle?: React.CSSProperties;
   paneStyle?: React.CSSProperties;


### PR DESCRIPTION
# BUG FIX

## Expected Behavior

When depending upon `react-split-pane`, the provided`index.d.ts` contains accurate type definitions for TypeScript

## Actual Behavior

When compiling a project that uses `react-split-pane`, the TypeScript compiler fails with the following error:

```
  ERROR in /Users/briandanielak/dev/transcriptase/node_modules/react-split-pane/index.d.ts(22,14):
  TS2709: Cannot use namespace 'Prefixer' as a type.
```

## What I Think Causes This Problem

The `index.d.ts` file [uses a default-export import syntax][1]. But, the DefinitelyTyped definitions for `inline-style-prefixer` [don't have a default export][2]. So `Prefixer` isn't a valid value.

[1]: https://github.com/tomkp/react-split-pane/blob/19b00f6fc7c7d0030d3de769f94d9af9077eb8ea/index.d.ts#L1-L2
[2]: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f8721b6253475d6f8267a9cc16c5bde6089314c6/types/inline-style-prefixer/index.d.ts#L9-L25

## What this fix proposes

Because the `createPrefixer()` function returns a value of type `Prefix`, I think the appropriate import syntax should be to import the `Prefix` type, rather than the entire module.

## System Configuration

- Node v10.12.0
- TypeScript Compiler v 3.0.3
- yarn v 1.12.1

---

**Before submitting a pull request,** please complete the following checklist:

- [X] The existing test suites (`yarn test`) all pass
- [ ] For any new features or bug fixes, both positive and negative test cases have been added
- [ ] For any new features, documentation has been added
- [ ] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [X] Format your code with [prettier](https://github.com/prettier/prettier) (`npm run prettier`).
